### PR TITLE
Addition for interoperability with other plugins

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,10 +4,9 @@ import Gun from 'gun/gun';
 
 Gun.on('opt', function(context) {
 
-  // Pass to next plugins
+  // Pass to subsequent opt handlers
   this.to.next(context);
 
-  
   const { level } = context.opt;
 
   // Filter out instances without the level option.

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 import Adapter from './Adapter';
 import Gun from 'gun/gun';
 
-Gun.on('opt', function(context) {
+Gun.on('opt', function (context) {
 
   // Pass to subsequent opt handlers
   this.to.next(context);

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,12 @@
 import Adapter from './Adapter';
 import Gun from 'gun/gun';
 
-Gun.on('opt', (context) => {
+Gun.on('opt', function(context) {
+
+  // Pass to next plugins
+  this.to.next(context);
+
+  
   const { level } = context.opt;
 
   // Filter out instances without the level option.


### PR DESCRIPTION
@PsychoLlama : Realized that this was missing. If it's not there, the options chain stops (no callbacks added via `Gun.on('opt')` will be called if added after this one.